### PR TITLE
Add error to clarify the need for wrapper elements within a marquee

### DIFF
--- a/marquee3k.js
+++ b/marquee3k.js
@@ -20,6 +20,11 @@
 
   class Marquee3k {
     constructor(element, options) {
+
+      if (element.children.length === 0) {
+        throw new Error("Encountered a marquee element without children, please supply a wrapper for your content");
+      }
+
       this.element = element;
       this.selector = options.selector;
       this.speed = element.dataset.speed || 0.25;


### PR DESCRIPTION
Quite a trivial addition which might help people out in the future, spent a couple of minutes scratching my head before realizing what was causing my "innerHTML of undefined" error.